### PR TITLE
Include cuda.h for CUDA_VERSION define

### DIFF
--- a/include/VisionCore/CUDAGenerics.hpp
+++ b/include/VisionCore/CUDAGenerics.hpp
@@ -12,6 +12,7 @@
 #ifdef VISIONCORE_CUDA_COMPILER
 
 #include <cuda_runtime.h>
+#include <cuda.h>
 
 namespace vc
 {


### PR DESCRIPTION
CUDA_VERSION is currently not defined anywhere and the preprocessor if statements default to one of the options. This causes compile errors for certain CUDA versions.